### PR TITLE
Change task data fields

### DIFF
--- a/lentille-bugzilla/test/Spec.hs
+++ b/lentille-bugzilla/test/Spec.hs
@@ -58,10 +58,10 @@ testBugToTaskData = testCase "bugToTaskData" go
       case toTaskData bz of
         (td : _tds) ->
           sequence_
-            [ tdIssueId td @=? "1791815",
+            [ tdTid td @=? "1791815",
               tdChangeUrl td @=? "https://review.opendev.org/764427",
-              tdIssueUrl td @=? "https://bugzilla.redhat.com/show_bug.cgi?id=1791815",
-              tdIssueType td @=? ["FutureFeature"]
+              tdUrl td @=? "https://bugzilla.redhat.com/show_bug.cgi?id=1791815",
+              tdTtype td @=? ["FutureFeature"]
             ]
         [] -> assertBool "No external bugs found" False
 

--- a/lentille/src/Lentille/Client.hs
+++ b/lentille/src/Lentille/Client.hs
@@ -165,10 +165,10 @@ instance ToJSON IsoTime where
 data TaskData = TaskData
   { tdUpdatedAt :: IsoTime,
     tdChangeUrl :: Text,
-    tdIssueType :: [Text],
-    tdIssueId :: Text,
-    tdIssueUrl :: Text,
-    tdIssueTitle :: Text,
+    tdTtype :: [Text],
+    tdTid :: Text,
+    tdUrl :: Text,
+    tdTitle :: Text,
     tdSeverity :: Text,
     tdPriority :: Text
   }


### PR DESCRIPTION
Remove the term "issue" from the TaskData field to align
with https://github.com/change-metrics/monocle/pull/332

- issue_url -> url
- issue_title -> title
- issue_id -> tid
- issue_type -> ttype